### PR TITLE
Fix broken import and pin dependency versions.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "warning_scraper"
-version = "0.1"
+version = "0.2"
 description = "A python script to scrape compiler warnings and generate summary reports."
 requires-python = ">=3.8"
 dependencies = [
-  "jinja2",
-  "pyparsing",
-  "chardet",
+  "jinja2==3.1.6",
+  "pyparsing==3.3.2",
+  "chardet==7.0.0",
 ]
 
 [project.scripts]

--- a/readme.md
+++ b/readme.md
@@ -144,3 +144,18 @@ The `allow_failure: true` setting ensures that:
 - The job is marked as failed/warning state when warnings exist  
 - Artifacts are still uploaded when the job fails
 - The overall pipeline status reflects the warning condition
+
+### Tip: Run it locally in docker to test how CI would do it
+
+```sh
+# run bash in python:3.12 docker container. Map current dir to /opt/src in the docker. (on windows cmd replace $(pwd) with %cd% )
+docker run -it --rm -v $(pwd):/opt/src -w /opt/src python:3.12 bash
+# Now inside container,
+# CD to warning_scraper dir, then install deps into docker container
+pip install .
+# set project dir (adjust as needed)
+export FW_DIR=/opt/src/my_firmware_dir
+# run warning_scraper
+warning_scraper --logfile ${FW_DIR}/build/build_log.txt --flavor gcc --format gitlab_json --output ${FW_DIR}/build/code_quality_report.json --exit-nonzero-on-warnings
+
+```

--- a/warning_scraper/FileParser.py
+++ b/warning_scraper/FileParser.py
@@ -7,7 +7,7 @@ from . import Cpplint
 from pathlib import Path
 from . import util
 import fnmatch
-from chardet.universaldetector import UniversalDetector
+from chardet import UniversalDetector
 
 #Used for parsing an entire file.  The file parser just loads the correct type of line parser,
 #and uses it to iterate over an entire file.


### PR DESCRIPTION
chardet upgrade from 6.0.0 to 7.0.0 caused error:
```
modulenotfounderror: No module named 'chardet.universaldetector'
```

- Fix broken import when chardet 7 released.
- Pin versions of deps to prevent breaking in the future. 
- Add tip to readme for simulating CI.