### PR TITLE
 Allow urlrelativeto to be absolute path

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,8 +75,9 @@ warning_scraper.py --logfile whatever.txt --flavor borland --gitsha abcd12342 --
 ### urlrelativeto
 
 If a warning was discovered in `C:\cirunner\12345\path\to\project\src\module\module.cpp`, you could 
-specify `--urlrelativeto project` at the commandline to store the path as relative to 'project', so you'd get
-`src\module\module.cpp` instead.
+specify the common folder name `--urlrelativeto project` at the commandline to store the path as relative to 'project', so you'd get `src\module\module.cpp` instead.
+
+Alternatively, you may specify the urlrelativeto as an absolute path prefix, i.e. `--urlrelativeto C:\cirunner\12345\path\to\project` to get the same result.  For gitlab CI, use `--urlrelativeto ${CI_PROJECT_DIR}` (added 2026-03-04)
 
 ### excludelist (added August 2021)
 
@@ -128,7 +129,7 @@ code-quality-job:
     - cd ${CI_PROJECT_DIR}/tools/warning_scraper
     - pip install .
     # Run python script to parse the build log and generate code quality report
-    - warning_scraper --logfile ${FW_DIR}/build/build_log.txt --flavor gcc --format gitlab_json --output ${FW_DIR}/build/code_quality_report.json --exit-nonzero-on-warnings
+    - warning_scraper --logfile ${FW_DIR}/build/build_log.txt --flavor gcc --format gitlab_json --urlrelativeto ${CI_PROJECT_DIR} --output ${FW_DIR}/build/code_quality_report.json --exit-nonzero-on-warnings
   artifacts:
     paths:
       - ${FW_DIR}/build/code_quality_report.json

--- a/warning_scraper/util.py
+++ b/warning_scraper/util.py
@@ -19,19 +19,46 @@ def stripleadingrelativefrom(inputf:Path):
 
 #given c:/whatever/this/thing/is/not/foo.py
 #and provided "thing" in argument frompos
-#return "/is/not/foo.py" if include = False
+#return "is/not/foo.py" if include = False
 #return "thing/is/not/foo.py" if include = True
+#
+#frompos can be either:
+#  - A folder name to search for in the path (e.g., "project")
+#  - An absolute path to make the result relative to (e.g., "/home/user/project")
 def getpathfrom(inputf:Path, frompos:str, include=False)->Path:
     result = Path("")
     if (frompos != None):
-        try:
-            idx = inputf.parts.index(frompos)
-            if include == False:
-                idx += 1
-            for part in inputf.parts[idx:]:
-                result = result.joinpath(part)
-        except ValueError:
-            result = stripleadingrelativefrom(inputf)
+        frompos_path = Path(frompos)
+
+        # First, try treating frompos as an absolute path
+        if frompos_path.is_absolute():
+            try:
+                # Convert inputf to absolute if it's relative
+                abs_inputf = inputf if inputf.is_absolute() else inputf.resolve()
+                result = abs_inputf.relative_to(frompos_path)
+            except (ValueError, OSError):
+                # If relative_to fails, fall back to folder name search
+                try:
+                    idx = inputf.parts.index(frompos_path.name)
+                    if include == False:
+                        idx += 1
+                    for part in inputf.parts[idx:]:
+                        result = result.joinpath(part)
+                except ValueError:
+                    result = stripleadingrelativefrom(inputf)
+        else:
+            # Treat frompos as a folder name to search for
+            try:
+                idx = inputf.parts.index(frompos)
+                if include == False:
+                    idx += 1
+                for part in inputf.parts[idx:]:
+                    result = result.joinpath(part)
+            except ValueError:
+                result = stripleadingrelativefrom(inputf)
+    else:
+        # If frompos is None, still strip leading relative paths
+        result = stripleadingrelativefrom(inputf)
 
     return result
 
@@ -56,5 +83,5 @@ def cleanforjson(text:str):
     if r'"' in text:
         text = text.replace(r'"', r"'")
 
-    
+
     return text


### PR DESCRIPTION
you may specify the urlrelativeto as an absolute path prefix, i.e. `--urlrelativeto C:\cirunner\12345\path\to\project` to get the same result.

This stays backward compatible with previous option to specify just folder name.