### PR TITLE
add new option to print warnings to console

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,10 +65,13 @@ command-line options:
 --urlrelativeto: will truncate the discovered file paths such that they are relative to this directory, more info below
 --excludelist: a text file containing a list of files that should be exlcluded from warnings.  The list can contain wildcards.
 --exit-nonzero-on-warnings: exit with non-zero code if warnings are detected (useful for CI/CD)
+--print-warnings: print warnings to console output
 ```
 
 Example invocation:
+```sh
 warning_scraper.py --logfile whatever.txt --flavor borland --gitsha abcd12342 --format html --outputfile out.html
+```
 
 ## Explanation of arguments
 
@@ -100,6 +103,24 @@ When the `--exit-nonzero-on-warnings` flag is specified, the tool will exit with
 
 This is particularly useful in CI/CD environments where you want the build pipeline to indicate failure when warnings are present.
 
+### print-warnings (added March 2026)
+
+When the `--print-warnings` flag is specified, all scraped warnings will be printed to the console in a human-readable format, organized by file and line number.
+
+This is useful if you want to view warnings directly in the log output without downloading report artifacts. You can use this flag:
+- **Alone**: To only print warnings to console (omit `--outputfile`)
+- **With `--outputfile`**: To both print warnings and generate a report file
+
+Example for console-only output:
+```sh
+warning_scraper --logfile build.log --flavor gcc --print-warnings
+```
+
+Example for both console and report:
+```sh
+warning_scraper --logfile build.log --flavor gcc --print-warnings --outputfile report.json --format gitlab_json
+```
+
 ## Example Gitlab CI
 
  For example, in GitLab CI you can use:
@@ -128,7 +149,8 @@ code-quality-job:
     - cd ${CI_PROJECT_DIR}/tools/warning_scraper
     - pip install .
     # Run python script to parse the build log and generate code quality report
-    - warning_scraper --logfile ${FW_DIR}/build/build_log.txt --flavor gcc --format gitlab_json --output ${FW_DIR}/build/code_quality_report.json --exit-nonzero-on-warnings
+    # The --print-warnings flag will display warnings in the job log for easy viewing
+    - warning_scraper --logfile ${FW_DIR}/build/build_log.txt --flavor gcc --format gitlab_json --output ${FW_DIR}/build/code_quality_report.json --print-warnings --exit-nonzero-on-warnings
   artifacts:
     paths:
       - ${FW_DIR}/build/code_quality_report.json

--- a/warning_scraper/warning_scraper.py
+++ b/warning_scraper/warning_scraper.py
@@ -21,8 +21,10 @@ def getargs():
     parser.add_argument(
         "--urlbase", help="the base URL path to locate the report artifact on your Gitlab server")
     parser.add_argument("--excludelist", help="path to the textfile containing files or directories to be included in wildcard format")
-    parser.add_argument("--exit-nonzero-on-warnings", action="store_true", 
+    parser.add_argument("--exit-nonzero-on-warnings", action="store_true",
                         help="exit with non-zero code if warnings are detected (useful for CI/CD)")
+    parser.add_argument("--print-warnings", action="store_true",
+                        help="print warnings to console output")
     args = parser.parse_args()
 
     if len(sys.argv) == 1:
@@ -67,14 +69,53 @@ def checkReport(args, fp):
             print("Generated json is invalid, please examine the json file with a json lint tool to debug.")
             sys.exit(1)
 
+def printWarnings(fp):
+    """Print warnings to console in a readable format"""
+    if len(fp.discoveredwarnings) == 0:
+        print("\nNo warnings found.")
+        return
+
+    print(f"\n{'='*80}")
+    print(f"Found {len(fp.discoveredwarnings)} warning(s):")
+    print(f"{'='*80}")
+
+    # Sort warnings by file path, then line number
+    sorted_warnings = sorted(fp.discoveredwarnings,
+                            key=lambda w: (str(w.fullpath), w.linenumber))
+
+    current_file = None
+    for idx, w in enumerate(sorted_warnings, 1):
+        # Print file header when it changes
+        if current_file != w.fullpath:
+            current_file = w.fullpath
+            print(f"\n{w.fullpath}")
+
+        # Print warning details
+        print(f"  Line {w.linenumber}:{w.colnumber if w.colnumber != -1 else '?'} [{w.severity.name.upper()}] {w.warningid}")
+        print(f"    {w.warningmessage}")
+        if w.warningline and w.fileopened:
+            print(f"    Code: {w.warningline}")
+        print()
+
+    print(f"{'='*80}")
+
 def main():
     args = getargs()
     fp = FileParser(args.flavor)
     fp.readFile(args.logfile, args.urlrelativeto)
     fp.removeExcludedWarnings(args.excludelist)
-    writeReport(args, fp)
-    checkReport(args, fp)
-    
+
+    # Print warnings to console if requested
+    if args.print_warnings:
+        printWarnings(fp)
+
+    # Generate report file if output file is specified
+    if args.outputfile:
+        writeReport(args, fp)
+        checkReport(args, fp)
+    elif not args.print_warnings:
+        print("Warning: No output file specified and --print-warnings not enabled. No output generated.")
+
     # Exit with non-zero code if warnings are found and the flag is set
     if args.exit_nonzero_on_warnings and len(fp.discoveredwarnings) > 0:
         print(f"Found {len(fp.discoveredwarnings)} warning(s), exiting with non-zero code")


### PR DESCRIPTION
When the `--print-warnings` flag is specified, all scraped warnings will be printed to the console in a human-readable format, organized by file and line number.

This is useful if you want to view warnings directly in the log output without downloading report artifacts. You can use this flag:
- **Alone**: To only print warnings to console (omit `--outputfile`)
- **With `--outputfile`**: To both print warnings and generate a report file

Example for console-only output:
```sh
warning_scraper --logfile build.log --flavor gcc --print-warnings
```

Example for both console and report:
```sh
warning_scraper --logfile build.log --flavor gcc --print-warnings --outputfile report.json --format gitlab_json
```