### PR TITLE
Bugfixes.

### DIFF
--- a/test/test_gcclineparser.py
+++ b/test/test_gcclineparser.py
@@ -16,3 +16,16 @@ class TestGccLines(unittest.TestCase):
         self.assertEqual(warning.fullpath, Path(r"/Projects/Export/vsbexport/../../../Core/Messages/helloworld.h"))
         self.assertEqual(warning.warningmessage, "'foo' has a field 'foo::m_type' whose type uses the anonymous namespace")
 
+    # test a line with a relative path and no warning ID in brackets at the end of the message
+    # created with: #pragma GCC warning "This is a test warning for the warning scraper tool."
+    def test_line_with_relative_path(self):        
+        line = r"../../../components/poco-core/src/poco_main.c:527:21: warning: This is a test warning for the warning scraper tool."
+        parser = GccLineParser()
+        parser.setLine(line)
+        parser.parseLine()
+        warning = parser.getWarningObject()
+        self.assertEqual(warning.linenumber, 527)
+        self.assertEqual(warning.colnumber, 21)
+        self.assertEqual(warning.warningid, "")
+        self.assertEqual(warning.fullpath, Path(r"../../../components/poco-core/src/poco_main.c"))
+        self.assertEqual(warning.warningmessage, "This is a test warning for the warning scraper tool.")

--- a/warning_scraper/Gcc.py
+++ b/warning_scraper/Gcc.py
@@ -20,7 +20,7 @@ class GccLineParser(LineParser):
 
     grammar = pp.SkipTo(pp_defs.GCCPOSITIONINFO)("file") + pp_defs.GCCPOSITIONINFO("pos") \
             + pp.Literal("warning:") + pp.White() \
-            + pp.SkipTo(pp_defs.BRACKETED("warningid") + pp.LineEnd(), include=True)("message")
+            + pp.restOfLine("fullmessage")
 
     def setGrammar(self, grammar):
         self.grammar = grammar
@@ -46,15 +46,22 @@ class GccLineParser(LineParser):
             except:
                 print("Error: Parser failed to match on line: {0}".format(self.rawline))
 
+            # Parse warning ID and message from fullmessage
             try:
-                warningobj.warningid = self.matches["warningid"].strip()
+                fullmessage = self.matches["fullmessage"].strip()
             except:
-                warningobj.warningid = ""
-
-            try:
-                warningobj.warningmessage = self.matches["message"].strip()
-            except:
-                warningobj.warningmessage = ""
+                fullmessage = ""
+            
+            # Set defaults
+            warningobj.warningid = ""
+            warningobj.warningmessage = fullmessage
+            
+            # Try to extract bracketed warning ID at the end
+            if fullmessage.endswith(']'):
+                bracket_start = fullmessage.rfind('[')
+                if bracket_start != -1:
+                    warningobj.warningid = fullmessage[bracket_start+1:-1].strip()
+                    warningobj.warningmessage = fullmessage[:bracket_start].strip()
 
             try:
                 warningobj.fullpath = Path(self.matches["file"])

--- a/warning_scraper/template/json/gitlab_code_quality.jinja
+++ b/warning_scraper/template/json/gitlab_code_quality.jinja
@@ -19,7 +19,7 @@
       "severity": "{{w.severity.name}}",
       "colnumber": "{{w.colnumber}}",
       "location": {
-        "path": "{{getpathfrom(w.fullpath, args.urlrelativeto).as_posix()}}",
+        "path": "{{cleanforjson(getpathfrom(w.fullpath, args.urlrelativeto).as_posix())}}",
         "lines": {
           "begin": {{w.linenumber}}
         }


### PR DESCRIPTION
- GCC warning sometimes doesn't include a bracketed type. E.g. when `#pragma GCC WARNING "testing warning"`
- Fixed a failing test on linux.  Json needs escaping backslashes in windows paths.